### PR TITLE
Disable experimental async option to avoid errors

### DIFF
--- a/app/src/lib/components/Overlay.svelte
+++ b/app/src/lib/components/Overlay.svelte
@@ -58,40 +58,34 @@
 	transition:slide={{ axis: 'x' }}
 	style="--width-factor: {$overlayWidth}"
 >
-	<svelte:boundary>
-		<!--svelte-ignore a11y_no_static_element_interactions -->
-		<div class="resize-handle" onmousedown={startExpand}></div>
-		{#if data.key === overlayKey.enum['view-help']}
-			<ViewHelpOverlay container={data.container} />
-		{:else if data.key === overlayKey.enum['members']}
-			<MembersOverlay container={data.container} users={data.users} />
-		{:else if data.key === overlayKey.enum['chapters']}
-			<ChaptersOverlay containers={data.containers} />
-		{:else if data.key === overlayKey.enum['relations']}
-			<RelationOverlay object={data.container} relatedContainers={data.relatedContainers} />
-		{:else if data.key === overlayKey.enum['measures']}
-			<MeasuresOverlay containers={data.containers} />
-		{:else if data.key === overlayKey.enum['measure-monitoring']}
-			<MeasureMonitoringOverlay container={data.container} containers={data.containers} />
-		{:else if data.key === overlayKey.enum['tasks']}
-			<TasksOverlay container={data.container} containers={data.containers} />
-		{:else if data.key === overlayKey.enum['indicator-catalog']}
-			<IndicatorCatalogOverlay
-				indicatorTemplates={data.indicatorTemplates}
-				indicators={data.indicators}
-			/>
-		{:else if data.key === overlayKey.enum['indicators']}
-			<IndicatorsOverlay containers={data.containers} />
-		{:else if data.key === overlayKey.enum['view']}
-			{#key data.container.guid}
-				<ViewOverlay container={data.container} revisions={data.revisions} />
-			{/key}
-		{/if}
-
-		{#snippet pending()}
-			<Header />
-		{/snippet}
-	</svelte:boundary>
+	<!--svelte-ignore a11y_no_static_element_interactions -->
+	<div class="resize-handle" onmousedown={startExpand}></div>
+	{#if data.key === overlayKey.enum['view-help']}
+		<ViewHelpOverlay container={data.container} />
+	{:else if data.key === overlayKey.enum['members']}
+		<MembersOverlay container={data.container} users={data.users} />
+	{:else if data.key === overlayKey.enum['chapters']}
+		<ChaptersOverlay containers={data.containers} />
+	{:else if data.key === overlayKey.enum['relations']}
+		<RelationOverlay object={data.container} relatedContainers={data.relatedContainers} />
+	{:else if data.key === overlayKey.enum['measures']}
+		<MeasuresOverlay containers={data.containers} />
+	{:else if data.key === overlayKey.enum['measure-monitoring']}
+		<MeasureMonitoringOverlay container={data.container} containers={data.containers} />
+	{:else if data.key === overlayKey.enum['tasks']}
+		<TasksOverlay container={data.container} containers={data.containers} />
+	{:else if data.key === overlayKey.enum['indicator-catalog']}
+		<IndicatorCatalogOverlay
+			indicatorTemplates={data.indicatorTemplates}
+			indicators={data.indicators}
+		/>
+	{:else if data.key === overlayKey.enum['indicators']}
+		<IndicatorsOverlay containers={data.containers} />
+	{:else if data.key === overlayKey.enum['view']}
+		{#key data.container.guid}
+			<ViewOverlay container={data.container} revisions={data.revisions} />
+		{/key}
+	{/if}
 </section>
 
 <style>

--- a/app/svelte.config.js
+++ b/app/svelte.config.js
@@ -12,10 +12,6 @@ const config = {
 		experimental: {
 			remoteFunctions: true
 		}
-	},
-
-	compilerOptions: {
-		experimental: { async: true }
 	}
 };
 


### PR DESCRIPTION
Navigating between pages sometimes resulted in errors related to a mismatch between the properties components were expecting and the actual data.