### PR TITLE
Comparison bar bugfixes

### DIFF
--- a/app/src/lib/components/CompareBar.svelte
+++ b/app/src/lib/components/CompareBar.svelte
@@ -5,6 +5,7 @@
 	import Close from '~icons/knotdots/close';
 	import MunicipalityPicker from '$lib/components/MunicipalityPicker.svelte';
 	import { compareState } from '$lib/stores';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		disclosure: ReturnType<typeof createDisclosure>;
@@ -41,6 +42,13 @@
 	function clearAll() {
 		compareState.set({ selectedMunicipalities: [], colorAssignments: {} });
 	}
+
+	// Open the picker dialog when the compare bar is expanded but no municipalities are selected
+	$effect(() => {
+		if ($disclosure.expanded && untrack(() => $compareState.selectedMunicipalities.length === 0)) {
+			openPicker();
+		}
+	});
 
 	// Assign colors to municipalities that don't have one yet
 	$effect(() => {

--- a/app/src/lib/components/Header.svelte
+++ b/app/src/lib/components/Header.svelte
@@ -318,6 +318,7 @@
 			use:sortBar.button
 		>
 			<Sort />
+			<span class="is-visually-hidden is-visually-hidden--mobile-only">{$_('sort')}</span>
 		</button>
 	{/if}
 
@@ -325,7 +326,6 @@
 		<button
 			class="dropdown-button dropdown-button--command"
 			type="button"
-			{@attach tooltip($_('compare'))}
 			use:compareBar.button
 			onclick={() => {
 				filterBar.close();
@@ -333,6 +333,7 @@
 			}}
 		>
 			<Compare />
+			<span>{$_('compare')}</span>
 		</button>
 	{/if}
 </div>

--- a/app/src/lib/components/Header.svelte
+++ b/app/src/lib/components/Header.svelte
@@ -302,7 +302,7 @@
 			use:filterBar.button
 		>
 			<Filter />
-			<span class="is-visually-hidden is-visually-hidden--mobile-only">{$_('filter')}</span>
+			<span class="is-visually-hidden--mobile-only">{$_('filter')}</span>
 			{#if activeFilters > 0 && !$filterBar.expanded}
 				<span class="indicator">{activeFilters}</span>
 			{/if}
@@ -318,6 +318,7 @@
 			use:sortBar.button
 		>
 			<Sort />
+			<span class="is-visually-hidden--mobile-only">{$_('sort')}</span>
 		</button>
 	{/if}
 
@@ -333,6 +334,7 @@
 			}}
 		>
 			<Compare />
+			<span class="is-visually-hidden--mobile-only">{$_('compare')}</span>
 		</button>
 	{/if}
 </div>
@@ -564,7 +566,7 @@
 
 	@layer visually-hidden {
 		@container (min-width: 60rem) {
-			.is-visually-hidden.is-visually-hidden--mobile-only {
+			.is-visually-hidden--mobile-only {
 				all: revert-layer;
 			}
 		}

--- a/app/src/lib/components/Header.svelte
+++ b/app/src/lib/components/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { signIn } from '@auth/sveltekit/client';
-	import { getContext } from 'svelte';
+	import { getContext, untrack } from 'svelte';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import { createDisclosure } from 'svelte-headlessui';
 	import { _ } from 'svelte-i18n';
@@ -43,6 +43,7 @@
 	import { createFeatureDecisions } from '$lib/features';
 	import {
 		isGoalContainer,
+		isIndicatorTemplateContainer,
 		isMeasureContainer,
 		isOrganizationalUnitContainer,
 		isOrganizationContainer,
@@ -98,10 +99,14 @@
 
 	let sortBar = createDisclosure({ label: $_('sort') });
 
-	let compareBar = createDisclosure({
-		label: $_('compare'),
-		expanded: $compareState.selectedMunicipalities.length > 0
-	});
+	let compareBar = $derived(
+		createDisclosure({
+			label: $_('compare'),
+			expanded:
+				untrack(() => $compareState.selectedMunicipalities.length > 0) &&
+				(isReportContainer(container) || isIndicatorTemplateContainer(container))
+		})
+	);
 
 	let selectedContext = $derived(
 		page.data.currentOrganizationalUnit ?? page.data.currentOrganization

--- a/app/src/lib/components/Header.svelte
+++ b/app/src/lib/components/Header.svelte
@@ -451,8 +451,10 @@
 		--indicator-background-color: var(--color-primary-700);
 
 		align-items: center;
+		container-type: inline-size;
 		display: flex;
 		flex-wrap: wrap;
+		font-size: 0.875rem;
 		gap: 0.75rem;
 		justify-content: end;
 		padding: 0 0.75rem 0.5rem;

--- a/app/src/lib/components/Header.svelte
+++ b/app/src/lib/components/Header.svelte
@@ -302,7 +302,7 @@
 			use:filterBar.button
 		>
 			<Filter />
-			<span class="is-visually-hidden--mobile-only">{$_('filter')}</span>
+			<span class="is-visually-hidden is-visually-hidden--mobile-only">{$_('filter')}</span>
 			{#if activeFilters > 0 && !$filterBar.expanded}
 				<span class="indicator">{activeFilters}</span>
 			{/if}
@@ -318,7 +318,6 @@
 			use:sortBar.button
 		>
 			<Sort />
-			<span class="is-visually-hidden--mobile-only">{$_('sort')}</span>
 		</button>
 	{/if}
 
@@ -334,7 +333,6 @@
 			}}
 		>
 			<Compare />
-			<span class="is-visually-hidden--mobile-only">{$_('compare')}</span>
 		</button>
 	{/if}
 </div>
@@ -566,7 +564,7 @@
 
 	@layer visually-hidden {
 		@container (min-width: 60rem) {
-			.is-visually-hidden--mobile-only {
+			.is-visually-hidden.is-visually-hidden--mobile-only {
 				all: revert-layer;
 			}
 		}

--- a/app/src/lib/components/NewIndicatorChart.svelte
+++ b/app/src/lib/components/NewIndicatorChart.svelte
@@ -63,6 +63,8 @@
 		)
 	]);
 
+	let allYears = $derived([...new Set(allData.map((d) => d.date.getFullYear()))].toSorted());
+
 	// Build color scale domain and range
 	let colorDomain = $derived(['current', ...comparisonValues.map((c) => c.municipalityGuid)]);
 	let colorRange = $derived([
@@ -161,6 +163,7 @@
 			width: currentWidth,
 			height: (currentWidth * 400) / 640, // Maintain the 640:400 aspect ratio
 			grid: true,
+			x: allYears.length === 1 ? { tickFormat: (d: Date) => String(d.getFullYear()) } : undefined,
 			y: { label: $_(unit), tickFormat: (d) => $number(d) },
 			color: {
 				domain: colorDomain,

--- a/app/src/lib/components/PickerDialog.svelte
+++ b/app/src/lib/components/PickerDialog.svelte
@@ -36,7 +36,7 @@
 </script>
 
 <dialog bind:this={dialog} oninput={(e) => e.stopPropagation()}>
-	<form method="dialog">
+	<div>
 		<div class="commands">
 			<span>{title}</span>
 
@@ -89,7 +89,7 @@
 		</div>
 
 		{@render content()}
-	</form>
+	</div>
 </dialog>
 
 <style>
@@ -113,7 +113,7 @@
 		width: calc(100vw - 10rem);
 	}
 
-	dialog > form {
+	dialog > div {
 		display: flex;
 		flex-direction: column;
 		height: 100%;


### PR DESCRIPTION
This pull request introduces several improvements to the `Header.svelte` component, enhances accessibility, and makes a minor visualization tweak in `NewIndicatorChart.svelte`. The main changes include refining the logic for displaying the compare bar, improving the accessibility of button labels, and updating the dialog structure in `PickerDialog.svelte`.

**Header logic and accessibility improvements:**

* Updated the logic for the `compareBar` in `Header.svelte` to only expand when there are selected municipalities and the container is either a report or indicator template, improving contextual accuracy. [[1]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fL101-R109) [[2]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fR46)
* Improved accessibility by ensuring visually hidden labels for filter, sort, and compare buttons are only hidden on mobile, and by adding missing visually hidden labels for the sort and compare buttons. [[1]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fL300-R305) [[2]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fR321) [[3]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fR337) [[4]](diffhunk://#diff-30a6c83d9097be09ef33a0622873d87061650fa1350542d8b91cddaeb312a50fL562-R569)

**Dialog structure update:**

* Refactored `PickerDialog.svelte` to replace the inner `<form>` with a `<div>`, updating corresponding CSS selectors for improved dialog flexibility and structure. [[1]](diffhunk://#diff-967ab4c94fd5abf2ee1191bcf1b3182bfd06e3464ebb2dba2e5252b5275a09ceL39-R39) [[2]](diffhunk://#diff-967ab4c94fd5abf2ee1191bcf1b3182bfd06e3464ebb2dba2e5252b5275a09ceL92-R92) [[3]](diffhunk://#diff-967ab4c94fd5abf2ee1191bcf1b3182bfd06e3464ebb2dba2e5252b5275a09ceL116-R116)

**Chart visualization tweak:**

* In `NewIndicatorChart.svelte`, added a special tick format for the x-axis when only one data point is present, improving readability for single-year charts.