### PR TITLE
Fix size of charts in cards

### DIFF
--- a/app/src/lib/components/NewIndicatorChart.svelte
+++ b/app/src/lib/components/NewIndicatorChart.svelte
@@ -20,7 +20,9 @@
 
 	let { container, relatedContainers = [], comparisonContainers }: Props = $props();
 
-	const currentOrgUnitName = $derived(page.data.currentOrganizationalUnit?.payload.name);
+	const currentOrgUnitName = $derived(
+		page.data.currentOrganizationalUnit?.payload.name ?? page.data.currentOrganization?.payload.name
+	);
 
 	let unit = $derived($_(container.payload.unit));
 

--- a/app/src/lib/components/NewIndicatorChart.svelte
+++ b/app/src/lib/components/NewIndicatorChart.svelte
@@ -219,6 +219,10 @@
 {/if}
 
 <style>
+	figure {
+		flex-grow: 1;
+	}
+
 	.chart-legend {
 		display: flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
This pull request makes improvements to the `NewIndicatorChart.svelte` component, focusing on enhancing the logic for displaying organizational unit names and refining the component's layout with new styles.

**Logic improvements:**

* Updated the logic for `currentOrgUnitName` to use the organizational unit name if available, otherwise fall back to the organization name. This ensures a name is always displayed even if the organizational unit is missing.

**Styling and layout enhancements:**

* Added new CSS styles for the `figure` element to ensure consistent layout within the card component.